### PR TITLE
Add tags column, but only for user-read

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,11 @@ Options:
   -e, --email TEXT              User email address  [required]
 ```
 
+**Note:** The CSV format for `user-read` is the same as `user-read-all` ([see
+below](#user-read-all)) with the exception of the `tags` column. This column can
+currently only be read on a user-by-user basis and thus is not included in
+`user-read-all` results.
+
 ## `user-read-all`
 
 Get details for all users in a given console. 

--- a/umapi_cli/cli.py
+++ b/umapi_cli/cli.py
@@ -101,7 +101,7 @@ def user_read(ctx, output_format, email):
 def user_read_all(ctx, output_format, out_file):
     """Get details for all users belonging to a console"""
 
-    fmtr = _formatter(output_format, _output_fh(out_file), OutputHandler('user_read'))
+    fmtr = _formatter(output_format, _output_fh(out_file), OutputHandler('user_read_all'))
     umapi_conn = ctx.obj['conn']
     query = UsersQuery(umapi_conn)
     report_total = True

--- a/umapi_cli/formatter.py
+++ b/umapi_cli/formatter.py
@@ -101,6 +101,18 @@ class OutputHandler:
             "username",
             "domain",
             "groups",
+            "tags",
+        ],
+        'user_read_all': [
+            "id",
+            "type",
+            "email",
+            "firstname",
+            "lastname",
+            "country",
+            "username",
+            "domain",
+            "groups",
         ],
         'group_read': [
             'groupName',


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add `tags` column to output spec of `user-read` command. This will enabled inclusion of the field for `pretty` and `json` output formats when `tags` attribute is present for the user. Will also add the `tags` column to CSV format regardless of whether `tags` attribute is set for user.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #5

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Need to support upcoming role tags feature.

## How Has This Been Tested?

Tested in stage against org that has EDU tags enabled.

**Note:** no users exist in that org with both `student` and `teacher` tags applied at the same time. That still needs to be tested.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
